### PR TITLE
setup helpers

### DIFF
--- a/datalad_osf/__init__.py
+++ b/datalad_osf/__init__.py
@@ -2,95 +2,28 @@
 
 __docformat__ = 'restructuredtext'
 
-from os.path import curdir
-from os.path import abspath
 
-from datalad.interface.base import Interface
-from datalad.interface.base import build_doc
-from datalad.support.param import Parameter
-from datalad.distribution.dataset import datasetmethod
-from datalad.interface.utils import eval_results
-from datalad.support.constraints import EnsureChoice
-
-from datalad.interface.results import get_status_dict
 
 # defines a datalad command suite
 # this symbol must be identified as a setuptools entrypoint
 # to be found by datalad
 command_suite = (
     # description of the command suite, displayed in cmdline help
-    "Demo DataLad command suite",
+    "DataLad extension for OSF support",
     [
         # specification of a command, any number of commands can be defined
         (
             # importable module that contains the command implementation
-            'datalad_osf',
+            'datalad_osf.create_sibling_osf',
             # name of the command class implementation in above module
-            'OSFHelloWorld',
+            'CreateSiblingOSF',
             # optional name of the command in the cmdline API
-            'osf-cmd',
+            'create-sibling-osf',
             # optional name of the command in the Python API
-            'osf_cmd'
+            'create_sibling_osf'
         ),
     ]
 )
-
-
-# decoration auto-generates standard help
-@build_doc
-# all commands must be derived from Interface
-class OSFHelloWorld(Interface):
-    # first docstring line is used a short description in the cmdline help
-    # the rest is put in the verbose help and manpage
-    """Short description of the command
-
-    Long description of arbitrary volume.
-    """
-
-    # parameters of the command, must be exhaustive
-    _params_ = dict(
-        # name of the parameter, must match argument name
-        language=Parameter(
-            # cmdline argument definitions, incl aliases
-            args=("-l", "--language"),
-            # documentation
-            doc="""language to say "hello" in""",
-            # type checkers, constraint definition is automatically
-            # added to the docstring
-            constraints=EnsureChoice('en', 'de')),
-    )
-
-    @staticmethod
-    # decorator binds the command to the Dataset class as a method
-    @datasetmethod(name='osf_cmd')
-    # generic handling of command results (logging, rendering, filtering, ...)
-    @eval_results
-    # signature must match parameter list above
-    # additional generic arguments are added by decorators
-    def __call__(language='en'):
-        if language == 'en':
-            msg = 'Hello!'
-        elif language == 'de':
-            msg = 'Tachchen!'
-        else:
-            msg = ("unknown language: '%s'", language)
-
-        # commands should be implemented as generators and should
-        # report any results by yielding status dictionaries
-        yield get_status_dict(
-            # an action label must be defined, the command name make a good
-            # default
-            action='demo',
-            # most results will be about something associated with a dataset
-            # (component), reported paths MUST be absolute
-            path=abspath(curdir),
-            # status labels are used to identify how a result will be reported
-            # and can be used for filtering
-            status='ok' if language in ('en', 'de') else 'error',
-            # arbitrary result message, can be a str or tuple. in the latter
-            # case string expansion with arguments is delayed until the
-            # message actually needs to be rendered (analog to exception messages)
-            message=msg)
 
 
 from datalad import setup_package

--- a/datalad_osf/create-osf-remote
+++ b/datalad_osf/create-osf-remote
@@ -1,0 +1,51 @@
+#!/usr/bin/env python
+
+#
+#  simple demo for a standalone convenience script
+#  creating an OSF project and appropriately call
+#  git-annex-initremote
+#
+#  Expects to be called fom within annex repository
+#
+#  arg 1: project title
+#  arg 2: remote name
+#  arg 3: (optional) path to be used within that project to store
+#         annex objects under
+
+import sys
+from datalad_osf.utils import (
+    create_project,
+    initialize_osf_remote
+)
+
+
+if __name__ == '__main__':
+
+    if sys.argv[1] == "-h" or len(sys.argv) > 4 or len(sys.argv) < 3:
+        print("Usage: create_project <project title> <remote-name> "
+              "[<path-within-project>]")
+        sys.exit(0)
+
+    project_title = sys.argv[1]
+    if not project_title:
+        raise ValueError("OSF project title required")
+    remote = sys.argv[2]
+    if not remote:
+        raise ValueError("a remote name is required")
+    if len(sys.argv) == 4:
+        objpath = sys.argv[3]
+    else:
+        objpath = "git-annex"
+
+    project_id = create_project(project_title)
+    print("Successfully create OSF project \"{}\" with ID {}"
+          .format(project_title, project_id))
+
+    initialize_osf_remote(remote=remote, project=project_id, objpath=objpath)
+
+    # Note: Hints on how to proceed or what else to do could be guided by
+    #       investigating the local repo's config (i.e. remote with URL
+    #       containing "github.com" -> more specific suggestion what and how to
+    #       link)
+    print("Done. Note, that you can link a repository to the project on OSF"
+          "by enabling the respective addon for GitHub/GitLab/BitBucket/etc.")

--- a/datalad_osf/create-osf-remote
+++ b/datalad_osf/create-osf-remote
@@ -37,9 +37,9 @@ if __name__ == '__main__':
     else:
         objpath = "git-annex"
 
-    project_id = create_project(project_title)
-    print("Successfully create OSF project \"{}\" with ID {}"
-          .format(project_title, project_id))
+    project_id, project_url = create_project(project_title)
+    print("Successfully create OSF project \"{}\" at {}"
+          .format(project_title, project_url))
 
     initialize_osf_remote(remote=remote, project=project_id, objpath=objpath)
 

--- a/datalad_osf/create_sibling_osf.py
+++ b/datalad_osf/create_sibling_osf.py
@@ -64,8 +64,6 @@ class CreateSiblingOSF(Interface):
         # NOTES:
         # - we prob. should check osf-special-remote availability upfront to
         #   fail early
-        # - create project on OSF first
-        # - initremote second
         # - publish-depends option?
         # - (try to) detect github/gitlab/bitbucket to suggest linking it on
         #   OSF and configure publish dependency
@@ -84,13 +82,29 @@ class CreateSiblingOSF(Interface):
         #   -> result_renderer
         #   -> needs to ne returned by create_project
 
+        # - option: Make public!
+
         proj_id, proj_url = create_project(title=title)
+        yield get_status_dict(action="create-project-osf",
+                              type="dataset",
+                              url=proj_url,
+                              id=proj_id,
+                              status="ok"
+                              )
+
         init_opts = ["encryption=none",
                      "type=external",
                      "externaltype=osf",
                      "autoenable=true",
                      "project={}".format(proj_id)]
+
         if path:
             init_opts += ["objpath={}".format(path)]
 
         ds.repo.init_remote(sibling, options=init_opts)
+        # TODO: add special remote name to result?
+        #       need to check w/ datalad-siblings conventions
+        yield get_status_dict(action="add-sibling-osf",
+                              type="dataset",
+                              status="ok"
+                              )

--- a/datalad_osf/create_sibling_osf.py
+++ b/datalad_osf/create_sibling_osf.py
@@ -1,6 +1,7 @@
 from os import environ
 from datalad.interface.base import Interface
 from datalad.interface.base import build_doc
+from datalad.interface.utils import ac
 from datalad.support.annexrepo import AnnexRepo
 from datalad.support.param import Parameter
 from datalad.distribution.dataset import (
@@ -34,6 +35,8 @@ def _get_credentials():
 class CreateSiblingOSF(Interface):
     """Create a dataset representation at OSF
     """
+
+    result_renderer = 'tailored'
 
     _params_ = dict(
         dataset=Parameter(
@@ -116,3 +119,22 @@ class CreateSiblingOSF(Interface):
                               type="dataset",
                               status="ok"
                               )
+
+    @staticmethod
+    def custom_result_renderer(res, **kwargs):
+        from datalad.ui import ui
+        status_str = "{action}({status}): "
+        if res['action'] == "create-project-osf":
+            ui.message("{action}({status}): {url}".format(
+                action=ac.color_word(res['action'], ac.BOLD),
+                status=ac.color_status(res['status']),
+                url=res['url'])
+            )
+        elif res['action'] == "add-sibling-osf":
+            ui.message("{action}({status})".format(
+                action=ac.color_word(res['action'], ac.BOLD),
+                status=ac.color_status(res['status']))
+            )
+        else:
+            from datalad.interface.utils import default_result_renderer
+            default_result_renderer(res, **kwargs)

--- a/datalad_osf/create_sibling_osf.py
+++ b/datalad_osf/create_sibling_osf.py
@@ -69,10 +69,20 @@ class CreateSiblingOSF(Interface):
         # - publish-depends option?
         # - (try to) detect github/gitlab/bitbucket to suggest linking it on
         #   OSF and configure publish dependency
+        #   -> prob. overkill; just make it clear in the doc
         # - add --recursive option
-        #
+        #       - recursive won't work easily. Need to think that through.
+        #       - would need a naming scheme for subdatasets
+        #       - flat on OSF or a tree?
+        #       - how do we detect something is there already, so we can skip
+        #         rather than duplicate (with a new name)?
+        #         osf-type-special-remote sufficient to decide it's not needed?
         # - adapt to conclusions in issue #30
         #   -> create those subcomponents
+        # - results need to report URL for created projects suitable for datalad
+        #   output formatting!
+        #   -> result_renderer
+        #   -> needs to ne returned by create_project
 
         proj_id = create_project(title=title)
         init_opts = ["encryption=none",

--- a/datalad_osf/create_sibling_osf.py
+++ b/datalad_osf/create_sibling_osf.py
@@ -1,7 +1,6 @@
-from os.path import curdir
-
 from datalad.interface.base import Interface
 from datalad.interface.base import build_doc
+from datalad.support.annexrepo import AnnexRepo
 from datalad.support.param import Parameter
 from datalad.distribution.dataset import (
     datasetmethod,
@@ -12,35 +11,76 @@ from datalad.interface.utils import eval_results
 from datalad.support.constraints import (
     EnsureNone,
     EnsureStr,
-    EnsureChoice,
-    EnsureBool,
 )
 from datalad.interface.results import get_status_dict
+from datalad_osf.utils import create_project
 
 
 @build_doc
 class CreateSiblingOSF(Interface):
-    """Short description of the command
-
-    Long description of arbitrary volume.
+    """Create a dataset representation at OSF
     """
 
     _params_ = dict(
         dataset=Parameter(
             args=("-d", "--dataset"),
-            doc=""""Dataset to extract metadata from. If no further
+            doc=""""Dataset to create a sibling for. If no further
         constraining path is given, metadata is extracted from all files
         of the dataset.""",
-            constraints=EnsureDataset() | EnsureNone()),
-        title=Parameter(),
-        path=Parameter(),
-        sibling=Parameter(),
+            constraints=EnsureDataset() | EnsureNone()
+        ),
+        title=Parameter(
+            args=("title",),
+            doc="""  """,
+            constraints=EnsureStr()
+        ),
+        sibling=Parameter(
+            args=("sibling",),
+            doc="""""",
+            constraints=EnsureStr()
+        ),
+        path=Parameter(
+            args=("--path",),
+            doc="""""",
+            constraints=EnsureStr() | EnsureNone()
+        ),
     )
 
     @staticmethod
     @datasetmethod(name='create_sibling_osf')
     @eval_results
-    def __call__(dataset=None, title=None, path=None, sibling=None):
+    def __call__(title, sibling, path=None, dataset=None):
         ds = require_dataset(dataset,
                              purpose="create OSF remote",
                              check_installed=True)
+        # we need an annex
+        if not isinstance(ds.repo, AnnexRepo):
+            yield get_status_dict(action="create-sibling-osf",
+                                  type="dataset",
+                                  status="impossible",
+                                  message="dataset has no annex")
+            return
+
+        # NOTES:
+        # - we prob. should check osf-special-remote availability upfront to
+        #   fail early
+        # - create project on OSF first
+        # - initremote second
+        # - publish-depends option?
+        # - (try to) detect github/gitlab/bitbucket to suggest linking it on
+        #   OSF and configure publish dependency
+        # - add --recursive option
+        #
+        # - adapt to conclusions in issue #30
+        #   -> create those subcomponents
+
+        proj_id = create_project(title=title)
+        init_opts = ["encryption=none",
+                     "type=external",
+                     "externaltype=osf",
+                     "autoenable=true",
+                     "project={}".format(proj_id)]
+        if path:
+            init_opts += ["objpath={}".format(path)]
+
+        ds.repo.init_remote(sibling, options=init_opts)

--- a/datalad_osf/create_sibling_osf.py
+++ b/datalad_osf/create_sibling_osf.py
@@ -1,0 +1,46 @@
+from os.path import curdir
+
+from datalad.interface.base import Interface
+from datalad.interface.base import build_doc
+from datalad.support.param import Parameter
+from datalad.distribution.dataset import (
+    datasetmethod,
+    EnsureDataset,
+    require_dataset
+)
+from datalad.interface.utils import eval_results
+from datalad.support.constraints import (
+    EnsureNone,
+    EnsureStr,
+    EnsureChoice,
+    EnsureBool,
+)
+from datalad.interface.results import get_status_dict
+
+
+@build_doc
+class CreateSiblingOSF(Interface):
+    """Short description of the command
+
+    Long description of arbitrary volume.
+    """
+
+    _params_ = dict(
+        dataset=Parameter(
+            args=("-d", "--dataset"),
+            doc=""""Dataset to extract metadata from. If no further
+        constraining path is given, metadata is extracted from all files
+        of the dataset.""",
+            constraints=EnsureDataset() | EnsureNone()),
+        title=Parameter(),
+        path=Parameter(),
+        sibling=Parameter(),
+    )
+
+    @staticmethod
+    @datasetmethod(name='create_sibling_osf')
+    @eval_results
+    def __call__(dataset=None, title=None, path=None, sibling=None):
+        ds = require_dataset(dataset,
+                             purpose="create OSF remote",
+                             check_installed=True)

--- a/datalad_osf/create_sibling_osf.py
+++ b/datalad_osf/create_sibling_osf.py
@@ -84,7 +84,7 @@ class CreateSiblingOSF(Interface):
         #   -> result_renderer
         #   -> needs to ne returned by create_project
 
-        proj_id = create_project(title=title)
+        proj_id, proj_url = create_project(title=title)
         init_opts = ["encryption=none",
                      "type=external",
                      "externaltype=osf",

--- a/datalad_osf/init-osf-remote
+++ b/datalad_osf/init-osf-remote
@@ -1,0 +1,53 @@
+#!/usr/bin/env python
+
+#
+#  simple demo for a standalone convenience wrapper
+#  around git-annex-initremote for an osf remote
+#
+#  Expects to be called fom within annex repository
+#
+#  arg 1: name for the remote
+#  arg 2: project ID of existing OSF project
+#  arg 3: (optional) path to be used within that project to store
+#         annex objects under
+
+import sys
+from datalad_osf.utils import initialize_osf_remote
+
+
+if __name__ == '__main__':
+
+    if sys.argv[1] == "-h" or len(sys.argv) > 4 or len(sys.argv) < 3:
+        print("Usage: init-osf-remote <remote-name> <osf-project-id> "
+              "[<path-within-project>]")
+        sys.exit(0)
+
+    remote = sys.argv[1]
+    if not remote:
+        raise ValueError("a remote name is required")
+    project = sys.argv[2]
+    if not project:
+        raise ValueError("OSF project ID required")
+    if len(sys.argv) == 4:
+        objpath = sys.argv[3]
+    else:
+        objpath = "git-annex"
+
+    initialize_osf_remote(remote=remote, project=project, objpath=objpath)
+
+
+#!/usr/bin/env python
+
+#
+#  simple demo for a standalone convenience script
+#  creating an OSF project and appropriately call
+#  git-annex-initremote
+#
+#  Expects to be called fom within annex repository
+#
+#  arg 1: project title
+#  arg 2: remote name
+#  arg 3: (optional) path to be used within that project to store
+#         annex objects under
+
+import sys

--- a/datalad_osf/tests/test_create_sibling_osf.py
+++ b/datalad_osf/tests/test_create_sibling_osf.py
@@ -1,7 +1,16 @@
+from datalad.api import (
+    Dataset,
+)
 from datalad.tests.utils import (
+    assert_equal,
+    assert_in,
+    assert_not_in,
+    assert_result_count,
     SkipTest,
     with_tree
 )
+from datalad_osf.utils import delete_project
+
 
 minimal_repo = {'ds': {'file1.txt': 'content',
                        'subdir': {'file2.txt': 'different content'}
@@ -15,16 +24,48 @@ def test_invalid_calls(path):
     # - impossible w/o dataset
     # - impossible w/o annex
     # - mandatory arguments
-    raise SkipTest("Needs test setup")
+    raise SkipTest("TODO")
 
 
 @with_tree(tree=minimal_repo)
-def test_create_osf(path):
+def test_create_osf_simple(path):
 
-    # - create the OSF project(s)
-    # - test result via osfclient or just test it being functional?
-    # - test for correct config in git-annex:remote.log
+    ds = Dataset(path).create(force=True)
+    ds.save()
 
-    # - annex-move and annex-get again
-    # - account for export when implemented
-    raise SkipTest("Needs test setup")
+    create_results = ds.create_sibling_osf(title="CI dl-create",
+                                           sibling="osf-storage")
+
+    assert_result_count(create_results, 2, status='ok', type='dataset')
+
+    # special remote is configured:
+    remote_log = ds.repo.call_git(['cat-file', 'blob', 'git-annex:remote.log'])
+    assert_in("project={}".format(create_results[0]['id']), remote_log)
+
+    # copy files over
+    ds.repo.copy_to('.', "osf-storage")
+    whereis = ds.repo.whereis('file1.txt')
+    here = ds.config.get("annex.uuid")
+    # files should be 'here' and on remote end:
+    assert_equal(len(whereis), 2)
+    assert_in(here, whereis)
+
+    # drop content here
+    ds.drop('.')
+    whereis = ds.repo.whereis('file1.txt')
+    assert_equal(len(whereis), 2)
+    assert_not_in(here, whereis)
+
+    # and get content again from remote:
+    ds.get('.')
+    whereis = ds.repo.whereis('file1.txt')
+    assert_equal(len(whereis), 2)
+    assert_in(here, whereis)
+
+    # clean remote end:
+    delete_project(create_results[0]['id'])
+
+
+def test_create_osf_existing():
+
+    raise SkipTest("TODO")

--- a/datalad_osf/tests/test_create_sibling_osf.py
+++ b/datalad_osf/tests/test_create_sibling_osf.py
@@ -1,0 +1,30 @@
+from datalad.tests.utils import (
+    SkipTest,
+    with_tree
+)
+
+minimal_repo = {'ds': {'file1.txt': 'content',
+                       'subdir': {'file2.txt': 'different content'}
+                       }
+                }
+
+
+@with_tree(tree=minimal_repo)
+def test_invalid_calls(path):
+
+    # - impossible w/o dataset
+    # - impossible w/o annex
+    # - mandatory arguments
+    raise SkipTest("Needs test setup")
+
+
+@with_tree(tree=minimal_repo)
+def test_create_osf(path):
+
+    # - create the OSF project(s)
+    # - test result via osfclient or just test it being functional?
+    # - test for correct config in git-annex:remote.log
+
+    # - annex-move and annex-get again
+    # - account for export when implemented
+    raise SkipTest("Needs test setup")

--- a/datalad_osf/tests/test_register.py
+++ b/datalad_osf/tests/test_register.py
@@ -1,11 +1,6 @@
-from datalad.tests.utils import assert_result_count
 
 
 def test_register():
     import datalad.api as da
-    assert hasattr(da, 'osf_cmd')
-    assert_result_count(
-        da.osf_cmd(),
-        1,
-        action='demo')
+    assert hasattr(da, 'create_sibling_osf')
 


### PR DESCRIPTION
Simplest version ATM works fine given that authentication is set up (still env vars).
A project "totally_new" is created on OSF, special-remote initialized and functioning:

```
$ datalad create-sibling-osf totally_new osf
$ git annex copy --to osf .
copy file1 (to osf...) 
ok
copy file2 (to osf...) 
ok
(recording state in git...)
```
This needs some more things to cover (particularly in light of #30) and tests, of course, which requires #20 to come to an conclusion.

I'll keep going ...


