### PR TITLE
Strip leading/trailing /s to get at the project ID

### DIFF
--- a/datalad_osf/remote.py
+++ b/datalad_osf/remote.py
@@ -89,7 +89,7 @@ class OSFRemote(SpecialRemote):
     def prepare(self):
         """"""
         project_id = posixpath.basename(
-            urlparse(self.annex.getconfig('project')).path)
+            urlparse(self.annex.getconfig('project')).path.strip(posixpath.sep))
 
         osf = OSF(
             username=os.environ['OSF_USERNAME'],


### PR DESCRIPTION
Pasting https://osf.io/tkrbw/ right off the web will crash mysteriously. because this will parse to /tkrbw/ -> ("/tkrbw", "") -> "".