### PR TITLE
Test decorator to create OSF project for CI tests and remove afterwards

### DIFF
--- a/datalad_osf/remote.py
+++ b/datalad_osf/remote.py
@@ -102,7 +102,7 @@ class OSFRemote(SpecialRemote):
             raise RemoteError(e)
         # we need to register the idea that this key is now present, but
         # we also want to avoid (re)requesting file info
-        if self._files:
+        if self._files is not None:
             # assign None to indicate that we know this key, but
             # have no info from OSF about it
             self._files[key] = None

--- a/datalad_osf/tests/test_remote.py
+++ b/datalad_osf/tests/test_remote.py
@@ -15,14 +15,15 @@ from datalad.utils import Path
 from datalad.tests.utils import (
     with_tempfile
 )
+from datalad_osf.utils import osf_project
 
 common_init_opts = ["encryption=none", "type=external", "externaltype=osf",
                     "autoenable=true"]
 
 
+@osf_project(title="CI osf-special-remote")
 @with_tempfile
-@with_tempfile
-def test_gitannex(store, dspath):
+def test_gitannex(osf_id, dspath):
     from datalad.cmd import (
         GitRunner,
         WitlessRunner
@@ -32,8 +33,9 @@ def test_gitannex(store, dspath):
     ds = Dataset(dspath).create()
 
     # add remote parameters here
-    init_remote_opts = []
+    init_remote_opts = ["project={}".format(osf_id)]
 
+    import pdb; pdb.set_trace()
     # add special remote
     init_opts = common_init_opts + []
     ds.repo.init_remote('osfproject', options=init_opts)

--- a/datalad_osf/tests/test_remote.py
+++ b/datalad_osf/tests/test_remote.py
@@ -13,17 +13,18 @@ from datalad.api import (
 )
 from datalad.utils import Path
 from datalad.tests.utils import (
-    with_tempfile
+    with_tempfile,
 )
-from datalad_osf.utils import osf_project
+from datalad_osf.utils import with_project
 
 common_init_opts = ["encryption=none", "type=external", "externaltype=osf",
                     "autoenable=true"]
 
 
-@osf_project(title="CI osf-special-remote")
+@with_project(title="CI osf-special-remote")
 @with_tempfile
 def test_gitannex(osf_id, dspath):
+
     from datalad.cmd import (
         GitRunner,
         WitlessRunner

--- a/datalad_osf/tests/test_remote.py
+++ b/datalad_osf/tests/test_remote.py
@@ -35,9 +35,8 @@ def test_gitannex(osf_id, dspath):
     # add remote parameters here
     init_remote_opts = ["project={}".format(osf_id)]
 
-    import pdb; pdb.set_trace()
     # add special remote
-    init_opts = common_init_opts + []
+    init_opts = common_init_opts + init_remote_opts
     ds.repo.init_remote('osfproject', options=init_opts)
 
     # run git-annex-testremote
@@ -46,5 +45,5 @@ def test_gitannex(osf_id, dspath):
     WitlessRunner(
         cwd=dspath,
         env=GitRunner.get_git_environ_adjusted()).run(
-            ['git', 'annex', 'testremote', 'osfproject']
+            ['git', 'annex', 'testremote', 'osfproject', "--fast"]
     )

--- a/datalad_osf/utils.py
+++ b/datalad_osf/utils.py
@@ -1,4 +1,4 @@
-from osfclient import OSF
+from datalad_osf.osfclient.osfclient import OSF
 from os import environ
 import json
 

--- a/datalad_osf/utils.py
+++ b/datalad_osf/utils.py
@@ -4,7 +4,7 @@ import json
 
 from datalad.utils import (
     optional_args,
-    better_wraps
+    wraps
 )
 
 
@@ -105,11 +105,10 @@ def initialize_osf_remote(remote, project,
 
 
 @optional_args
-def osf_project(f, title, category="project"):
+def with_project(f, title=None, category="project"):
 
-    @better_wraps(f)
+    @wraps(f)
     def new_func(*args, **kwargs):
-
         proj_id, proj_url = create_project(title, category=category)
         try:
             return f(*(args + (proj_id,)), **kwargs)

--- a/datalad_osf/utils.py
+++ b/datalad_osf/utils.py
@@ -2,6 +2,13 @@ from osfclient import OSF
 from os import environ
 import json
 
+from datalad.utils import (
+    optional_args,
+    better_wraps
+)
+
+
+# TODO: token auth!
 osf = OSF(username=environ['OSF_USERNAME'],
           password=environ['OSF_PASSWORD'])
 
@@ -95,3 +102,18 @@ def initialize_osf_remote(remote, project,
 
     import subprocess
     subprocess.run(["git", "annex", "initremote", remote] + init_opts)
+
+
+@optional_args
+def osf_project(f, title, category="project"):
+
+    @better_wraps(f)
+    def new_func(*args, **kwargs):
+
+        proj_id, proj_url = create_project(title, category=category)
+        try:
+            return f(*(args + (proj_id,)), **kwargs)
+        finally:
+            delete_project(proj_id)
+
+    return new_func


### PR DESCRIPTION
I think this is ready.
Provides and makes use of a test decorator as described in title.
Fixes special remote so it actually passes `git annex testremote`.
Travis now passes. Github workflows still lack any credentials to succeed.

