### PR TITLE
TST: comment out username and pw secrets, rely on token auth

### DIFF
--- a/.github/workflows/test_crippledfs.yml
+++ b/.github/workflows/test_crippledfs.yml
@@ -44,9 +44,10 @@ jobs:
       env:
         # forces all test repos/paths into the VFAT FS
         TMPDIR: /crippledfs
-        OSF_USERNAME: ${{ secrets.OSF_USERNAME }}
+        # Token authentication should suffice, disabling the other secrets
+        #OSF_USERNAME: ${{ secrets.OSF_USERNAME }}
+        #OSF_PASSWORD: ${{ secrets.OSF_PASSWORD }}
         OSF_TOKEN: ${{ secrets.OSF_TOKEN }}
-        OSF_PASSWORD: ${{ secrets.OSF_PASSWORD }}
       run: |
         mkdir -p __testhome__
         cd __testhome__

--- a/.github/workflows/test_win2019.yml
+++ b/.github/workflows/test_win2019.yml
@@ -40,9 +40,10 @@ jobs:
         python -m pip install .
     - name: Run tests
       env:
-        OSF_USERNAME: ${{ secrets.OSF_USERNAME }}
+        # Token authentication should suffice, disabling the other secrets
+        #OSF_USERNAME: ${{ secrets.OSF_USERNAME }}
+        #OSF_PASSWORD: ${{ secrets.OSF_PASSWORD }}
         OSF_TOKEN: ${{ secrets.OSF_TOKEN }}
-        OSF_PASSWORD: ${{ secrets.OSF_PASSWORD }}
       run: |
         mkdir -p __testhome__
         cd __testhome__


### PR DESCRIPTION
@mjboos do you remember which secret in ``.travis.yml`` is which? #60 should allow complete reliance on token, so lets try to disable username and password.