### PR TITLE
Add modes for create-sibling-osf

### DIFF
--- a/datalad_osf/create_sibling_osf.py
+++ b/datalad_osf/create_sibling_osf.py
@@ -11,6 +11,7 @@ from datalad.distribution.dataset import (
 )
 from datalad.interface.utils import eval_results
 from datalad.support.constraints import (
+    EnsureChoice,
     EnsureNone,
     EnsureStr,
 )
@@ -56,12 +57,17 @@ class CreateSiblingOSF(Interface):
             doc="""""",
             constraints=EnsureStr()
         ),
+        mode=Parameter(
+            args=("--mode",),
+            doc=""" """,
+            constraints=EnsureChoice("annexstore", "exporttree")
+        )
     )
 
     @staticmethod
     @datasetmethod(name='create_sibling_osf')
     @eval_results
-    def __call__(title, sibling, dataset=None):
+    def __call__(title, sibling, dataset=None, mode="annexstore"):
         ds = require_dataset(dataset,
                              purpose="create OSF remote",
                              check_installed=True)
@@ -111,6 +117,9 @@ class CreateSiblingOSF(Interface):
                      "externaltype=osf",
                      "autoenable=true",
                      "project={}".format(proj_id)]
+
+        if mode == "exporttree":
+            init_opts += ["exporttree=yes"]
 
         ds.repo.init_remote(sibling, options=init_opts)
         # TODO: add special remote name to result?

--- a/datalad_osf/tests/test_create_sibling_osf.py
+++ b/datalad_osf/tests/test_create_sibling_osf.py
@@ -78,6 +78,32 @@ def test_create_osf_simple(path):
         delete_project(osf.session, create_results[0]['id'])
 
 
+@with_tree(tree=minimal_repo)
+def test_create_osf_export(path):
+
+    ds = Dataset(path).create(force=True)
+    ds.save()
+
+    create_results = ds.create_sibling_osf(title="CI dl-create",
+                                           sibling="osf-storage",
+                                           mode="exporttree")
+
+    assert_result_count(create_results, 2, status='ok', type='dataset')
+
+    # if we got here, we created something at OSF;
+    # make sure, we clean up afterwards
+    try:
+
+        # for now just run an export and make sure it doesn't fail
+        ds.repo.call_git(['annex', 'export', 'HEAD', '--to', 'osf-storage'])
+
+    finally:
+        # clean remote end:
+        cred = _get_credentials()
+        osf = OSF(**cred)
+        delete_project(osf.session, create_results[0]['id'])
+
+
 def test_create_osf_existing():
 
     raise SkipTest("TODO")


### PR DESCRIPTION
This enhances `datalad create-sibling-osf` with a `--mode` switch. ATM possible values are `annexstore` (default) and `exporttree`.