### PR TITLE
Skip tests that cannot pass because of missing credentials

### DIFF
--- a/datalad_osf/tests/test_create_sibling_osf.py
+++ b/datalad_osf/tests/test_create_sibling_osf.py
@@ -6,6 +6,7 @@ from datalad.tests.utils import (
     assert_in,
     assert_not_in,
     assert_result_count,
+    skip_if,
     SkipTest,
     with_tree
 )
@@ -13,6 +14,9 @@ from datalad.utils import Path
 from datalad_osf.utils import delete_project
 from datalad_osf.create_sibling_osf import _get_credentials
 from datalad_osf.osfclient.osfclient import OSF
+from datalad_osf.tests.utils import (
+    setup_credentials,
+)
 
 
 minimal_repo = {'ds': {'file1.txt': 'content',
@@ -30,6 +34,7 @@ def test_invalid_calls(path):
     raise SkipTest("TODO")
 
 
+@skip_if(cond=not any(setup_credentials().values()), msg='no OSF credentials')
 @with_tree(tree=minimal_repo)
 def test_create_osf_simple(path):
 
@@ -78,6 +83,7 @@ def test_create_osf_simple(path):
         delete_project(osf.session, create_results[0]['id'])
 
 
+@skip_if(cond=not any(setup_credentials().values()), msg='no OSF credentials')
 @with_tree(tree=minimal_repo)
 def test_create_osf_export(path):
 
@@ -104,6 +110,7 @@ def test_create_osf_export(path):
         delete_project(osf.session, create_results[0]['id'])
 
 
+@skip_if(cond=not any(setup_credentials().values()), msg='no OSF credentials')
 def test_create_osf_existing():
 
     raise SkipTest("TODO")

--- a/datalad_osf/tests/test_remote.py
+++ b/datalad_osf/tests/test_remote.py
@@ -15,8 +15,12 @@ from datalad.utils import Path
 from datalad.tests.utils import (
     with_tempfile,
     skip_if_on_windows,
+    skip_if,
 )
-from datalad_osf.tests.utils import with_project
+from datalad_osf.tests.utils import (
+    with_project,
+    setup_credentials,
+)
 
 common_init_opts = ["encryption=none", "type=external", "externaltype=osf",
                     "autoenable=true"]
@@ -26,6 +30,7 @@ common_init_opts = ["encryption=none", "type=external", "externaltype=osf",
 # remote. It might just be that the SHA256 key paths get too long
 # https://github.com/datalad/datalad-osf/issues/71
 @skip_if_on_windows
+@skip_if(cond=not any(setup_credentials().values()), msg='no OSF credentials')
 @with_project(title="CI osf-special-remote")
 @with_tempfile
 def test_gitannex(osf_id, dspath):


### PR DESCRIPTION
Give message 'no OSF credentials' to make this clear.

This is important, because PRs from other forks will not get to see
the configured credentials.