### PR TITLE
Fix `create-sibling-osf -s` and make uniform with other DataLad command

### DIFF
--- a/datalad_osf/create_sibling_osf.py
+++ b/datalad_osf/create_sibling_osf.py
@@ -99,7 +99,7 @@ class CreateSiblingOSF(Interface):
             doc="""Title of the to-be created OSF project.""",
             constraints=EnsureStr()
         ),
-        sibling=Parameter(
+        name=Parameter(
             args=("-s", "--name",),
             doc="""name of the to-be initialized osf-special-remote""",
             constraints=EnsureStr()
@@ -114,7 +114,7 @@ class CreateSiblingOSF(Interface):
     @staticmethod
     @datasetmethod(name='create_sibling_osf')
     @eval_results
-    def __call__(title, sibling="osf", dataset=None, mode="annexstore"):
+    def __call__(title, name="osf", dataset=None, mode="annexstore"):
         ds = require_dataset(dataset,
                              purpose="create OSF remote",
                              check_installed=True)
@@ -168,7 +168,7 @@ class CreateSiblingOSF(Interface):
         if mode == "exporttree":
             init_opts += ["exporttree=yes"]
 
-        ds.repo.init_remote(sibling, options=init_opts)
+        ds.repo.init_remote(name, options=init_opts)
         # TODO: add special remote name to result?
         #       need to check w/ datalad-siblings conventions
         yield get_status_dict(action="add-sibling-osf",

--- a/datalad_osf/tests/test_create_sibling_osf.py
+++ b/datalad_osf/tests/test_create_sibling_osf.py
@@ -44,7 +44,7 @@ def test_create_osf_simple(path):
     file1 = Path('ds') / "file1.txt"
 
     create_results = ds.create_sibling_osf(title="CI dl-create",
-                                           sibling="osf-storage")
+                                           name="osf-storage")
 
     assert_result_count(create_results, 2, status='ok', type='dataset')
 
@@ -91,7 +91,7 @@ def test_create_osf_export(path):
     ds.save()
 
     create_results = ds.create_sibling_osf(title="CI dl-create",
-                                           sibling="osf-storage",
+                                           name="osf-storage",
                                            mode="exporttree")
 
     assert_result_count(create_results, 2, status='ok', type='dataset')


### PR DESCRIPTION
Specifically rename the `sibling` option to `name`, as in "create a
sibling with this name".

Fixes gh-87