### PR TITLE
--mode {annexstore,exporttree} -> --mode {annex,export}

### DIFF
--- a/datalad_osf/create_sibling_osf.py
+++ b/datalad_osf/create_sibling_osf.py
@@ -74,13 +74,13 @@ class CreateSiblingOSF(Interface):
 
     This will create a project on OSF and initialize
     an osf special remote to point to it. There are two modes
-    this can operate in: 'annexstore' and 'exporttree'.
+    this can operate in: 'annex' and 'export'.
     The former uses the OSF project as a key-value store, that
     can be used to by git-annex to copy data to and retrieve
     data from (potentially by any clone of the original dataset).
     The latter allows to use 'git annex export' to publish a
     snapshot of a particular version of the dataset. Such an OSF
-    project will - in opposition to the 'annexstore' - be
+    project will - in opposition to the 'annex' - be
     human-readable.
     """
 
@@ -107,14 +107,14 @@ class CreateSiblingOSF(Interface):
         mode=Parameter(
             args=("--mode",),
             doc=""" """,
-            constraints=EnsureChoice("annexstore", "exporttree")
+            constraints=EnsureChoice("annex", "export")
         )
     )
 
     @staticmethod
     @datasetmethod(name='create_sibling_osf')
     @eval_results
-    def __call__(title, name="osf", dataset=None, mode="annexstore"):
+    def __call__(title, name="osf", dataset=None, mode="annex"):
         ds = require_dataset(dataset,
                              purpose="create OSF remote",
                              check_installed=True)
@@ -165,7 +165,7 @@ class CreateSiblingOSF(Interface):
                      "autoenable=true",
                      "project={}".format(proj_id)]
 
-        if mode == "exporttree":
+        if mode == "export":
             init_opts += ["exporttree=yes"]
 
         ds.repo.init_remote(name, options=init_opts)

--- a/datalad_osf/tests/test_create_sibling_osf.py
+++ b/datalad_osf/tests/test_create_sibling_osf.py
@@ -92,7 +92,7 @@ def test_create_osf_export(path):
 
     create_results = ds.create_sibling_osf(title="CI dl-create",
                                            name="osf-storage",
-                                           mode="exporttree")
+                                           mode="export")
 
     assert_result_count(create_results, 2, status='ok', type='dataset')
 

--- a/docs/source/exporthumandata.rst
+++ b/docs/source/exporthumandata.rst
@@ -55,7 +55,7 @@ We are now going to use datalad to create a sibling dataset on OSF with name `os
 
 .. code-block:: bash
 
-     $ datalad create-sibling-osf -s osf OSF_PROJECT_NAME --mode exporttree             
+     $ datalad create-sibling-osf -s osf OSF_PROJECT_NAME --mode export
 
 After that we can export the current state (the `HEAD`) of our dataset in human readable form to OSF:
 


### PR DESCRIPTION
I do not see what the longer labels contribute in addition. Moreover,
`annex` and `export` are the actual terms that can be found in the git-annex
docs -- using different terms may make people wonder if there is
something more to them -- which is not the case.