### PR TITLE
[Doc] several minor fixes

### DIFF
--- a/docs/source/exportdatacode.rst
+++ b/docs/source/exportdatacode.rst
@@ -1,25 +1,23 @@
 
-Export version-controlled data to OSF and code to Github
+Export version-controlled data to OSF and code to GitHub
 ********************************************************
 
-Imagine you are a PhD student and want to collaborate on a fun little side 
+Imagine you are a PhD student and want to collaborate on a fun little side
 project with a student at another institute. It is quite obvious for the two of
-you that your code will be hosted on Github_. And you also know enough about 
+you that your code will be hosted on GitHub_. And you also know enough about
 DataLad, that using it for the whole project will be really beneficial.
 
-But what about the data you are collecting? 
+But what about the data you are collecting?
 The Dropbox is already full (`DataLad third party providers <http://handbook.datalad.org/en/latest/basics/101-138-sharethirdparty.html>`_). And Amazon services don't seem to be
 your best alternative.
-Suddenly you remember, that you got an OSF_ account recently, and that there is
-`this <https://github.com/datalad/datalad-osf/>`_ nice DataLad extension 
-set up a SpecialRemote on OSF_.
+Suddenly you remember, that you got an OSF_ account recently, and that there is this nice `Datalad extension <https://github.com/datalad/datalad-osf/>`_ to set up a SpecialRemote on OSF_.
 
 Walk through
 ------------
 
 Installation
 ^^^^^^^^^^^^
-For installation checkout the installation page of the documentation.  
+For installation checkout the installation page of the documentation.
 
 .. toctree::
 
@@ -31,14 +29,14 @@ Creating an Example Dataset
 
 As a very first step you want to set up a DataLad Dataset. For this you should
 run. In all examples a `$` in front indicates a new line in the Bash-Shell,
-copying it will prevent your code from execution. 
+copying it will prevent your code from execution.
 
 .. code-block:: bash
 
     $ datalad create collab_osf
 
 After having created the dataset we want to populate it with some content (just
-like in the Handbook). Importantly we don't want to upload this file on Github, only on OSF - in the real world this could be your data that is too large to upload to Github.
+like in the Handbook). Importantly we don't want to upload this file on GitHub, only on OSF - in the real world this could be your data that is too large to upload to GitHub.
 
 .. code-block:: bash
 
@@ -48,7 +46,7 @@ like in the Handbook). Importantly we don't want to upload this file on Github, 
     -m "add beginners guide on bash" \
     -O books/bash_guide.pdf
 
-And we also want to add a text file, which will be saved on Github_ - in your case this could be the code you are using.
+And we also want to add a text file, which will be saved on GitHub_ - in your case this could be the code you are using.
 
 .. code-block:: bash
 
@@ -57,8 +55,8 @@ And we also want to add a text file, which will be saved on Github_ - in your ca
     $ echo "This is just an example file just to show the different ways of saving data in a DataLad Dataset." > example.txt
     $ datalad save --to-git -m "created an example.txt"
 
-We now have a Dataset with one file that can be worked on using Github and one 
-that should be tracked using `git-annex`. 
+We now have a Dataset with one file that can be worked on using GitHub and one
+that should be tracked using `git-annex`.
 
 Setting up the OSF Remote
 ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -76,20 +74,19 @@ We are now going to use datalad to create a sibling dataset on OSF with name `os
 
     $ datalad create-sibling-osf -s osf OSF_PROJECT_NAME
 
-Setting up Github Remote
+Setting up GitHub Remote
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-We can set-up a Github Remote with name `github` and include a publish dependency with OSF - that way, when we publish our dataset to Github, the data files get automatically uploaded to OSF.
+We can set-up a GitHub Remote with name `github` and include a publish dependency with OSF - that way, when we publish our dataset to GitHub, the data files get automatically uploaded to OSF.
 
 .. code-block:: bash
 
     $ datalad create-sibling-github REPRONAME -s github --github-login GITHUB_NAME --publish-depends osf
     $ datalad publish . --to github --transfer-data all
 
-This will publish example.txt in code/ to Github and only add the folder structure and symbolic links for all other file; at the same time it will upload the data to OSF - this way you can let OSF handle your data and Github your code.
+This will publish example.txt in code/ to GitHub and only add the folder structure and symbolic links for all other file; at the same time it will upload the data to OSF - this way you can let OSF handle your data and GitHub your code.
 
 
 
 .. _OSF: https://www.osf.io/
-.. _Github: https://www.github.com/
-
+.. _GitHub: https://www.github.com/

--- a/docs/source/exporthumandata.rst
+++ b/docs/source/exporthumandata.rst
@@ -2,8 +2,8 @@ Export a human-readable dataset to OSF
 **************************************
 
 Imagine you have been creating a reproducible workflow using DataLad from the
-get go. Everything is finished now, code, data, and paper are ready. Last thing 
-to do: Publish your data. 
+get go. Everything is finished now, code, data, and paper are ready. Last thing
+to do: Publish your data.
 
 Using datalad-osf makes this really convenient.
 
@@ -12,7 +12,7 @@ Walk through
 
 Installation
 ^^^^^^^^^^^^
-For installation checkout the installation page of the documentation.  
+For installation checkout the installation page of the documentation.
 
 .. toctree::
 
@@ -21,14 +21,14 @@ For installation checkout the installation page of the documentation.
 
 Creating an Example Dataset
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-We will create a small example DataLad Dataset to show the functionality. 
+We will create a small example DataLad Dataset to show the functionality.
 
 .. code-block:: bash
 
     $ datalad create collab_osf
     # collab_osf being the name of your new dataset
     # In all examples a `$` in front indicates a new line in the Bash-Shell
-    # Copying the $ will prevent your code from execution. 
+    # Copying the $ will prevent your code from execution.
 
 After having created the dataset we want to populate it with some content (just
 like in the Handbook):
@@ -45,7 +45,7 @@ Setting up the OSF Remote
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 To use OSF as a storage, you need to provide either your OSF credentials or an OSF access token.
-You can create such a token in your account settings (`Personal access token` and then `Create token`), make sure to create a `full_write` token to be able to create OSF projects and upload data to OSF. 
+You can create such a token in your account settings (`Personal access token` and then `Create token`), make sure to create a `full_write` token to be able to create OSF projects and upload data to OSF.
 
 .. code-block:: bash
 
@@ -62,6 +62,3 @@ After that we can export the current state (the `HEAD`) of our dataset in human 
 .. code-block:: bash
 
     git annex export HEAD --to YOUR_OSF_REMOTE_NAME
-
-.. _OSF: https://www.osf.io/
-.. _Github: https://www.github.com/

--- a/docs/source/intro.rst
+++ b/docs/source/intro.rst
@@ -1,19 +1,19 @@
 Introduction
 ------------
 
-
 Goal of the extension
 ^^^^^^^^^^^^^^^^^^^^^
 
-This extension aims to allow DataLad to work with the Open Science Framework (OSF). This is done by transforming storage on the Open Science Framework (OSF) into a `git-annex <https://git-annex.branchable.com/>`_  repository. 
+This extension aims to allow DataLad to work with the Open Science Framework (OSF). This is done by transforming storage on the Open Science Framework (OSF) into a `git-annex <https://git-annex.branchable.com/>`_  repository.
 
 What can I use this extension for?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 You can use this extension to use the OSF as a special remote to store data in the annex  of a dataset. With this, you can `datalad publish` a dataset to GitHub or similar services and the data to the OSF (via a publication dependency).
-The extension is most beneficial for easy access to data stored on OSF via Github. If you are sharing your dataset via OSF and code via Github, this will allow smooth integration of both along with unified version management provided by DataLad.
+The extension is most beneficial for easy access to data stored on OSF via GitHub. If you are sharing your dataset via OSF and code via GitHub, this will allow smooth integration of both along with unified version management provided by DataLad.
 
 What can I **not** use this extension for?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-This tool does not work for data that is stored in a storage service other than OSF. Please refer `here <https://git-annex.branchable.com/special_remotes/>`_ for a list of supported data storage services via git-annex special remote framework.
+This tool does not work for data that is stored in a storage service other than OSF.
+Please refer to the `list of special remotes <https://git-annex.branchable.com/special_remotes/>`_ as hosted by the git-annex website for other storage services.

--- a/docs/source/settingup.rst
+++ b/docs/source/settingup.rst
@@ -6,23 +6,22 @@ Requirements
 
 - DataLad
 
-Before being able to use the extension, you need to have DataLad installed, which relies on `git-annex <git-annex.branchable.com/>`_, `Git <git-scm.com/>`_ and Python. If you don't have DataLad installed yet, please follow the instructions `here <http://handbook.datalad.org/en/latest/intro/installation.html>`_.
-
+Before being able to use the extension, you need to have DataLad installed, which relies on `git-annex <git-annex.branchable.com/>`_, `git <git-scm.com/>`_ and `Python <https://www.python.org/>`_.
+If you don't have DataLad installed yet, please follow the instructions from `the datalad handbook <http://handbook.datalad.org/en/latest/intro/installation.html>`_.
 
 - An account on the OSF
 
 You need an OSF account to be able to interact with it. If you don't have an account yet, `register here <https://osf.io/register>`_.
 
-- An account on repository-hosting accounts
+- An account on a git repository hosting site
 
-You should consider having an account on one or more repository hosting sites such as `GitHub <https://github.com/join?ref_cta=Sign+up&ref_loc=header+logged+out&ref_page=%2F&source=header-home>`_ , `GitLab <https://gitlab.com/users/sign_up>`_, `Bitbucket <https://bitbucket.org/account/signup/>`_ or similar"
+You should consider having an account on one or more repository hosting sites such as `GitHub <https://github.com/join>`_ , `GitLab <https://gitlab.com/users/sign_up>`_, `Bitbucket <https://bitbucket.org/account/signup/>`_ or similar"
 
+Installation
+------------
 
-Developer installation
------------------------
+Before you can start using the extension, you have to install it.
 
-Before you can start using the extension, you have to install it. To do this, open your shell and type:
+``datalad-osf`` is a package on `pypi <https://pypi.org/project/datalad-osf/>`_, so you can open your shell and type: ``pip install datalad-osf``.
 
-``pip install -e [--user] git+https://github.com/datalad/datalad-osf#egg=datalad-osf``
-
-Note: once packed up for PyPi and uploaded, use ``pip install datalad-osf``
+If you want to use the most recent development version, use the following command instead: ``pip install -e git+https://github.com/datalad/datalad-osf#egg=datalad-osf``


### PR DESCRIPTION
Hi datalad-osf team!

I followed your progress throughout the Brainhack -> really nice work! :slightly_smiling_face:  A pity I didn't have enough time to participate myself.

I have an OSF / datalad dataset myself from the times before this new datalad/datalad-osf extension, and I was going through the docs to see whether I can convert my "hacky" dataset to use this extension (didn't find a solution, will open an issue on this soon).

While going through the docs I took the liberty to suggest some changes.

- clarify the installation section, distinguishing developer and stable installation
- some minor rephrasings
- consistently capitalizing GitHub
- making links meaningful: (e.g., [Google](https://google.com), instead of [here](https://google.com))

My editor also fixed some trailing whitespace along the way. I hope the diff is not too unreadable.

Thanks for your work, and see you soon in an issue I'll open up :-)