### PR TITLE
Fix USER/PWD authentication

### DIFF
--- a/datalad_osf/utils.py
+++ b/datalad_osf/utils.py
@@ -113,7 +113,7 @@ def get_credentials(allow_interactive=True):
         return dict(
             token=environ.get('OSF_TOKEN', None),
             username=environ.get('OSF_USERNAME', None),
-            password=environ.get('OSF_USERNAME', None),
+            password=environ.get('OSF_PASSWORD', None),
         )
 
     # fall back on DataLad credential manager


### PR DESCRIPTION
Authentication via env vars setting username and password failed, because of a simple copy and paste error, that somehow managed to make it through review.

@sappelhoff This does fix it for me, does for you, too?