### PR TITLE
DBG: Switch git-annex versions

### DIFF
--- a/.github/workflows/test_win2019.yml
+++ b/.github/workflows/test_win2019.yml
@@ -26,8 +26,9 @@ jobs:
     - name: Set up git-annex
       run: |
         # latest version
-        python -c "import urllib.request as r; r.urlretrieve('https://downloads.kitenet.net/git-annex/windows/current/git-annex-installer.exe', 'C:\\git-annex-installer.exe')"
+        #python -c "import urllib.request as r; r.urlretrieve('https://downloads.kitenet.net/git-annex/windows/current/git-annex-installer.exe', 'C:\\git-annex-installer.exe')"
         # specific version mih uses to debug on real win10 box
+        python -c "import urllib.request as r; r.urlretrieve('http://store.datalad.org/git-annex/windows/git-annex_8.20200309.exe', 'C:\\git-annex-installer.exe')"
         7z x -o"C:\\Program Files\Git" C:\\git-annex-installer.exe
     - name: Install dependencies
       run: |


### PR DESCRIPTION
This change downgrades git-annex from 20200720.2-g8bfa7990b to
8.20200309. The latter is used on our Windows machine
and in DataLad core, and with this change, test stalls observed in
gh-126 and gh-127 do not surface anymore.