### PR TITLE
MNT: Add keyring to requirements

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -16,6 +16,7 @@ python_requires = >= 3.5
 install_requires =
     datalad >= 0.13.0rc2
     annexremote >= 1.4.0
+    keyring >= 20.0
     # from osfclient
     requests
     tqdm


### PR DESCRIPTION
Keyring versions prior to 20.0.0 came with dependencies to outdated versions of SecretStorage that
couldn't handle token authentication.
Fixes #123