### PR TITLE
Improve error handling in git-remote

### DIFF
--- a/datalad_osf/git_remote.py
+++ b/datalad_osf/git_remote.py
@@ -474,15 +474,21 @@ class LZMAZipFile(zipfile.ZipFile):
 
 
 def main():
-    if len(sys.argv) < 3:
-        raise ValueError("Usage: git-remote-osf REMOTE-NAME URL")
+    try:
+        if len(sys.argv) < 3:
+            raise ValueError("Usage: git-remote-osf REMOTE-NAME URL")
 
-    remote, url = sys.argv[1:3]
-    # no fallback, must be present
-    gitdir = os.environ['GIT_DIR']
+        remote, url = sys.argv[1:3]
+        # no fallback, must be present
+        gitdir = os.environ['GIT_DIR']
 
-    osf = OSFGitRemote(gitdir, remote, url)
-    osf.communicate()
+        osf = OSFGitRemote(gitdir, remote, url)
+        osf.communicate()
+    except Exception as e:
+        # Receiving an exception here is "fatal" by definition.
+        # Mimicking git's error reporting style.
+        print("fatal: " + str(e), file=sys.stderr)
+        sys.exit(1)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Don't let git-remote print a standard exception output with traceback,
but just the message. This doesn't resolve issue #142 entirely but at
least removes the traceback from user output.

Assuming PR #141 being merged, change looks like this:

Before this patch:
```
❱ git clone osf://2ynvg/sdf/sfd                                                                                                                                                                                                                                                                  1 !
Cloning into 'sfd'...
fatal: bad revision 'HEAD'
Traceback (most recent call last):
  File "/home/ben/venvs/datalad-osf-dev/bin/git-remote-osf", line 33, in <module>
    sys.exit(load_entry_point('datalad-osf', 'console_scripts', 'git-remote-osf')())
  File "/home/ben/work/hacking/datalad-osf/datalad_osf/git_remote.py", line 484, in main
    osf = OSFGitRemote(gitdir, remote, url)
  File "/home/ben/work/hacking/datalad-osf/datalad_osf/git_remote.py", line 60, in __init__
    raise RuntimeError("Only URLs of type osf://<PROJECT ID> are "
RuntimeError: Only URLs of type osf://<PROJECT ID> are supported. Got: osf://2ynvg/sdf/sfd
```

After:

```
❱ git clone osf://2ynvg/sdf/sfd                                                                                                                                                                                                                                                                130 !
Cloning into 'sfd'...
fatal: bad revision 'HEAD'
fatal: Only URLs of type osf://<PROJECT ID> are supported. Got: osf://2ynvg/sdf/sfd
```