### PR TITLE
Port tests to pytest, address deprecations

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -75,11 +75,27 @@ environment:
     # MacOS core tests
     - ID: MacP38
       DTS: datalad_osf
-      APPVEYOR_BUILD_WORKER_IMAGE: macOS
+      APPVEYOR_BUILD_WORKER_IMAGE: macos-monterey
       PY: 3.8
       INSTALL_GITANNEX: git-annex
       DATALAD_LOCATIONS_SOCKETS: /Users/appveyor/DLTMP/sockets
       CODECOV_BINARY: https://uploader.codecov.io/latest/macos/codecov
+
+
+# do not run the CI if only documentation changes were made
+# documentation builds are tested elsewhere and cheaper
+skip_commits:
+  files:
+    - docs/
+    - changelog.d/
+    - .github/
+    - CHANGELOG.md
+    - CITATION.cff
+    - CONTRIBUTORS
+    - LICENSE
+    - Makefile
+    - README.md
+    - readthedocs.yml
 
 
 # it is OK to specify paths that may not exist for a particular test run
@@ -152,8 +168,8 @@ install:
 
 
 build_script:
-  - pip install -r requirements-devel.txt
-  - pip install .
+  - python -m pip install -r requirements-devel.txt
+  - python -m pip install .
 
 
 #after_build:
@@ -172,8 +188,9 @@ test_script:
   #- sh: mkdir __testhome__
   #- cd __testhome__
     # run test selecion (--traverse-namespace needed from Python 3.8 onwards)
-  - cmd: python -m nose --traverse-namespace -s -v -A "not (turtle)" --with-cov --cover-package datalad_osf %DTS%
-  - sh:  python -m nose --traverse-namespace -s -v -A "not (turtle)" --with-cov --cover-package datalad_osf ${DTS}
+  - cmd: python -m pytest -s -v -m "not (turtle)" -k "%KEYWORDS%" --cov=datalad_osf --pyargs %DTS%
+    # also add --cov datalad, because some core test runs may not touch -next code
+  - sh:  PATH=$PWD/../tools/coverage-bin:$PATH python -m pytest -s -v -m "not (turtle)" -k "$KEYWORDS" --cov=datalad_osf --pyargs ${DTS}
 
 
 after_test:

--- a/datalad_osf/__init__.py
+++ b/datalad_osf/__init__.py
@@ -37,9 +37,6 @@ command_suite = (
 )
 
 
-from datalad import setup_package
-from datalad import teardown_package
-
 from ._version import get_versions
 __version__ = get_versions()['version']
 del get_versions

--- a/datalad_osf/conftest.py
+++ b/datalad_osf/conftest.py
@@ -1,0 +1,22 @@
+from datalad.conftest import setup_package
+
+from datalad_next.tests.fixtures import (
+    # no test can leave global config modifications behind
+    check_gitconfig_global,
+    # no test can leave secrets behind
+    check_plaintext_keyring,
+    # function-scope config manager
+    datalad_cfg,
+    # function-scope, Dataset instance
+    dataset,
+    # function-scope, Dataset instance with underlying repository
+    existing_dataset,
+)
+
+from datalad_osf.tests.fixtures import (
+    # standard test dataset setup used throughout the datalad-osf tests
+    minimal_dataset,
+    osf_credentials,
+    osf_credentials_or_skip,
+    osf_node,
+)

--- a/datalad_osf/create_sibling_osf.py
+++ b/datalad_osf/create_sibling_osf.py
@@ -19,10 +19,7 @@ from datalad.distribution.dataset import (
     EnsureDataset,
     require_dataset
 )
-from datalad.interface.utils import (
-    ac,
-    eval_results,
-)
+from datalad.interface.base import eval_results
 from datalad.support.constraints import (
     EnsureChoice,
     EnsureNone,
@@ -30,6 +27,7 @@ from datalad.support.constraints import (
     EnsureBool,
 )
 from datalad.interface.results import get_status_dict
+from datalad.interface.utils import ac
 from osfclient import OSF
 from datalad_osf.utils import (
     create_node,

--- a/datalad_osf/credentials.py
+++ b/datalad_osf/credentials.py
@@ -17,7 +17,7 @@ from datalad.distribution.dataset import (
     datasetmethod,
     EnsureDataset,
 )
-from datalad.interface.utils import (
+from datalad.interface.base import (
     eval_results,
 )
 from datalad.support.constraints import (

--- a/datalad_osf/tests/fixtures.py
+++ b/datalad_osf/tests/fixtures.py
@@ -1,0 +1,48 @@
+import pytest
+
+
+@pytest.fixture(autouse=False, scope="function")
+def minimal_dataset(existing_dataset):
+    ds = existing_dataset
+    (ds.pathobj / 'file1.txt').write_text('content')
+    (ds.pathobj / 'subdir').mkdir()
+    (ds.pathobj / 'subdir' / 'file2.txt').write_text('different content')
+    ds.save()
+
+    yield ds
+
+
+@pytest.fixture(autouse=False, scope="session")
+def osf_credentials():
+    """Yields credential dict from get_credentials() suitable of OSF client"""
+    from datalad_osf.utils import get_credentials
+    cred = get_credentials(allow_interactive=False)
+    yield cred
+
+
+@pytest.fixture(autouse=False, scope="function")
+def osf_credentials_or_skip(osf_credentials):
+    if not any(osf_credentials.values()):
+        pytest.skip(reason='no OSF credentials')
+
+    yield osf_credentials
+
+
+@pytest.fixture(autouse=False, scope="function")
+def osf_node(osf_credentials_or_skip):
+    from datalad_osf.utils import (
+        create_node,
+        delete_node,
+    )
+    from osfclient import OSF
+    osf = OSF(**osf_credentials_or_skip)
+
+    title = 'Temporary DataLad CI project'
+    category = "data"
+
+    node_id, proj_url = create_node(
+        osf.session, title, category=category,
+    )
+    yield node_id
+
+    delete_node(osf.session, node_id)

--- a/datalad_osf/tests/test_register.py
+++ b/datalad_osf/tests/test_register.py
@@ -11,4 +11,3 @@
 def test_register():
     import datalad.api as da
     assert hasattr(da, 'create_sibling_osf')
-

--- a/datalad_osf/tests/test_remote.py
+++ b/datalad_osf/tests/test_remote.py
@@ -7,21 +7,7 @@
 #
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 
-from datalad.api import (
-    Dataset,
-)
-from datalad.utils import Path
-from datalad.tests.utils import (
-    with_tempfile,
-    skip_if_on_windows,
-    skip_if,
-)
-from datalad_osf.tests.utils import (
-    with_node,
-)
-from datalad_osf.utils import (
-    get_credentials,
-)
+from datalad_next.tests.utils import skip_if_on_windows
 
 common_init_opts = ["encryption=none", "type=external", "externaltype=osf",
                     "autoenable=true"]
@@ -31,17 +17,12 @@ common_init_opts = ["encryption=none", "type=external", "externaltype=osf",
 # remote. It might just be that the SHA256 key paths get too long
 # https://github.com/datalad/datalad-osf/issues/71
 @skip_if_on_windows
-@skip_if(cond=not any(get_credentials().values()), msg='no OSF credentials')
-@with_node(title="CI osf-special-remote")
-@with_tempfile
-def test_gitannex(osf_id, dspath):
+def test_gitannex(osf_node, minimal_dataset):
     from datalad.cmd import GitWitlessRunner
-    dspath = Path(dspath)
-
-    ds = Dataset(dspath).create()
+    ds = minimal_dataset
 
     # add remote parameters here
-    init_remote_opts = ["node={}".format(osf_id)]
+    init_remote_opts = ["node={}".format(osf_node)]
 
     # add special remote
     init_opts = common_init_opts + init_remote_opts
@@ -52,7 +33,7 @@ def test_gitannex(osf_id, dspath):
     # want to see it in test build's output log.
     # TODO use AnnexRepo._call_annex(..., protocol=None) with 0.14+
     GitWitlessRunner(
-        cwd=dspath,
+        cwd=ds.path,
         env=GitWitlessRunner.get_git_environ_adjusted()).run(
             ['git', 'annex', 'testremote', 'osfproject', "--fast"]
     )

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -1,8 +1,6 @@
 # requirements for a development environment
-nose
-nose-exclude
+-e .[devel]
 mock
-coverage
 sphinx
 sphinx_rtd_theme
 docutils<0.18

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,20 +12,19 @@ classifiers =
     Programming Language :: Python :: 3
 
 [options]
-python_requires = >= 3.5
+python_requires = >= 3.7
 install_requires =
     datalad >= 0.18.4
+    datalad_next >= 1.0.0b2
     annexremote >= 1.4.0
     osfclient >= 0.0.5
-test_requires =
-    nose
-    coverage
 packages = find:
 include_package_data = True
 
 [options.extras_require]
 devel =
-    nose
+    pytest
+    pytest-cov
     coverage
 
 [options.packages.find]

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,7 @@ classifiers =
 [options]
 python_requires = >= 3.5
 install_requires =
-    datalad >= 0.13.0
+    datalad >= 0.18.4
     annexremote >= 1.4.0
     osfclient >= 0.0.5
 test_requires =


### PR DESCRIPTION
This PR brings to most urgently needed changes to restore functionality and reconnect with datalad development:

- updated dependencies, and address deprecations since datalad v0.18
- Closes #165 