### PR TITLE
Go with recent git-annex for linux tests too

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -63,8 +63,8 @@ environment:
       APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu2004
       INSTALL_SYSPKGS: python3-virtualenv
       CODECOV_BINARY: https://uploader.codecov.io/latest/linux/codecov
-      # system git-annex is way too old, use better one
-      INSTALL_GITANNEX: git-annex -m deb-url --url http://snapshot.debian.org/archive/debian/20201228T023115Z/pool/main/g/git-annex/git-annex_8.20201127-1_amd64.deb
+      # go with a recent snapshot
+      INSTALL_GITANNEX: git-annex -m snapshot
     # Windows core tests
     - ID: WinP38
       DTS: datalad_osf
@@ -160,7 +160,9 @@ install:
   # Install git-annex on windows, otherwise INSTALL_SYSPKGS can be used
   # deploy git-annex, if desired
   - cmd: IF DEFINED INSTALL_GITANNEX datalad-installer --sudo ok %INSTALL_GITANNEX%
-  - sh: "[ -n \"${INSTALL_GITANNEX}\" ] && datalad-installer --sudo ok ${INSTALL_GITANNEX}"
+  - sh: tools/appveyor/install-git-annex ${INSTALL_GITANNEX}
+  # enable the git-annex provisioned by the installer
+  - sh: "[ -f ${HOME}/dlinstaller_env.sh ] && . ${HOME}/dlinstaller_env.sh || true"
 
 
 #before_build:

--- a/tools/appveyor/install-git-annex
+++ b/tools/appveyor/install-git-annex
@@ -1,0 +1,14 @@
+#!/bin/bash
+#
+# Install git-annex. Any environment setup to source would be
+# written to ${HOME}/dlinstaller_env.sh
+#
+set -e -u
+
+# no install requested -> exit
+[ -z "$1" ] && exit 0 || true
+
+# assumes a virtualenv or equivalent python env
+# get the installer for this
+python -m pip install datalad-installer${DATALAD_INSTALLER_VERSION:-}
+datalad-installer -E ${HOME}/dlinstaller_env.sh --sudo ok $*


### PR DESCRIPTION
Before this change, the tests used (today):

- win: 10.20230407-g9c242af171
- mac: 10.20230407
- linux: 8.20201127

There is hardly any point in sticking to an old git-annex version.

Closes #166